### PR TITLE
[20기 임유진] Modify : 마이페이지 백엔드 테스트 완료, 데이터 구조 변경에 맞게 수정

### DIFF
--- a/public/data/userArchiveData.json
+++ b/public/data/userArchiveData.json
@@ -1,0 +1,24 @@
+{
+  "result": [
+    {
+      "title": "영화제목",
+      "rating": "3",
+      "thumbnail": "해당 영화의 썸네일 url"
+    },
+    {
+      "title": "영화제목",
+      "rating": "4",
+      "thumbnail": "해당 영화의 썸네일 url"
+    },
+    {
+      "title": "영화제목",
+      "rating": "1",
+      "thumbnail": "해당 영화의 썸네일 url"
+    },
+    {
+      "title": "영화제목",
+      "rating": "2.5",
+      "thumbnail": "해당 영화의 썸네일 url"
+    }
+  ]
+}

--- a/public/data/userArchiveData.json
+++ b/public/data/userArchiveData.json
@@ -1,24 +1,9 @@
 {
   "result": [
     {
-      "title": "영화제목",
-      "rating": "3",
-      "thumbnail": "해당 영화의 썸네일 url"
-    },
-    {
-      "title": "영화제목",
-      "rating": "4",
-      "thumbnail": "해당 영화의 썸네일 url"
-    },
-    {
-      "title": "영화제목",
-      "rating": "1",
-      "thumbnail": "해당 영화의 썸네일 url"
-    },
-    {
-      "title": "영화제목",
-      "rating": "2.5",
-      "thumbnail": "해당 영화의 썸네일 url"
+      "userName": "김영차",
+      "moviesCount": 45,
+      "wantedCount": 3
     }
   ]
 }

--- a/public/data/userWantedData.json
+++ b/public/data/userWantedData.json
@@ -1,0 +1,20 @@
+{
+  "result": [
+    {
+      "title": "영화제목",
+      "thumbnail": " 해당 영화의 썸네일 url"
+    },
+    {
+      "title": "영화제목",
+      "thumbnail": " 해당 영화의 썸네일 url"
+    },
+    {
+      "title": "영화제목",
+      "thumbnail": " 해당 영화의 썸네일 url"
+    },
+    {
+      "title": "영화제목",
+      "thumbnail": " 해당 영화의 썸네일 url"
+    }
+  ]
+}

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -6,6 +6,7 @@ import Footer from './pages/CommonComponents/Footer';
 // import login
 // import mypage
 import Navbar from './pages/CommonComponents/Navbar';
+import MyPage from './pages/MyPage/MyPage';
 
 class Routes extends React.Component {
   render() {
@@ -15,7 +16,7 @@ class Routes extends React.Component {
         <Switch>
           <Route exact path="/" component={Main}></Route>
           {/* <Route exact path="/contents" component={}></Route> */}
-          {/* <Route exact path="/myPage" component={}></Route> */}
+          <Route exact path="/mypage" component={MyPage}></Route>
         </Switch>
         <Footer />
       </Router>

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -4,7 +4,7 @@ import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import Main from './pages/Main/Main';
 import Footer from './pages/CommonComponents/Footer';
 import Navbar from './pages/CommonComponents/Navbar';
-import ReviewPage from './pages/ReviewPage/ReviewPage';
+// import ReviewPage from './pages/ReviewPage/ReviewPage';
 import MovieDetail from './pages/MovieDetail/MovieDetail';
 import MyPage from './pages/MyPage/MyPage';
 
@@ -16,17 +16,12 @@ class Routes extends React.Component {
         <Switch>
           <Route exact path="/" component={Main}></Route>
           <Route exact path="/moviedetail" component={MovieDetail}></Route>
-          <Route exact path="/review" component={ReviewPage}></Route>
+          {/* <Route exact path="/review" component={ReviewPage}></Route> */}
           <Route exact path="/mypage" component={MyPage}></Route>;
         </Switch>
-        {location.pathname !== '/review' && <Footer />}
+        <Footer />
       </Router>
     );
   }
 }
 export default Routes;
-
-/* global history */
-/* global location */
-/* global window */
-/* eslint no-restricted-globals: ["off"] */

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -3,11 +3,10 @@ import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 
 import Main from './pages/Main/Main';
 import Footer from './pages/CommonComponents/Footer';
-// import login
-// import mypage
 import Navbar from './pages/CommonComponents/Navbar';
-import MyPage from './pages/MyPage/MyPage';
+import ReviewPage from './pages/ReviewPage/ReviewPage';
 import MovieDetail from './pages/MovieDetail/MovieDetail';
+import MyPage from './pages/MyPage/MyPage';
 
 class Routes extends React.Component {
   render() {
@@ -16,14 +15,19 @@ class Routes extends React.Component {
         <Navbar />
         <Switch>
           <Route exact path="/" component={Main}></Route>
-          {/* <Route exact path="/movieDetail" component={MovieDetail}></Route> */}
-          {/* <Route exact path="/contents" component={}></Route> */}
-          <Route exact path="/mypage" component={MyPage}></Route>
+          <Route exact path="/moviedetail" component={MovieDetail}></Route>
+          <Route exact path="/review" component={ReviewPage}></Route>
+          <Route exact path="/mypage" component={MyPage}></Route>;
         </Switch>
-        <Footer />
+        {location.pathname !== '/review' && <Footer />}
       </Router>
     );
   }
 }
-
 export default Routes;
+
+/* global history */
+/* global location */
+/* global window */
+
+/* eslint no-restricted-globals: ["off"] */

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -19,15 +19,9 @@ class Routes extends React.Component {
           <Route exact path="/review" component={ReviewPage}></Route>
           <Route exact path="/mypage" component={MyPage}></Route>;
         </Switch>
-        {location.pathname !== '/review' && <Footer />}
+        <Footer />
       </Router>
     );
   }
 }
 export default Routes;
-
-/* global history */
-/* global location */
-/* global window */
-
-/* eslint no-restricted-globals: ["off"] */

--- a/src/pages/MyPage/MyPage.js
+++ b/src/pages/MyPage/MyPage.js
@@ -4,6 +4,31 @@ import './MyPage.scss';
 export default class MyPage extends Component {
   constructor(props) {
     super(props);
+    this.state = {
+      userRatedData: [],
+    };
+  }
+
+  componentDidMount() {
+    let token = localStorage.getItem('TOKEN') || '';
+    fetch(
+      '/data/userArchiveData.json'
+      //  {
+      //   headers: {
+      //     Authorization: token,
+      //   },
+      // }
+    )
+      .then(res => {
+        if (res.status === 200) {
+          return res.json();
+        }
+      })
+      .then(userRatedData => {
+        this.setState({
+          userRatedData: userRatedData['result'],
+        });
+      });
   }
 
   render() {

--- a/src/pages/MyPage/MyPage.js
+++ b/src/pages/MyPage/MyPage.js
@@ -1,0 +1,52 @@
+import React, { Component } from 'react';
+import './MyPage.scss';
+
+export default class MyPage extends Component {
+  render() {
+    return (
+      <section className="myPageSection">
+        <div className="myPageContainer">
+          <div className="myHeader">
+            <i class="fas fa-cog"></i>
+          </div>
+          <div className="myContents">
+            <header className="myProfile">
+              <div className="myProfileColumn">
+                <img
+                  alt="userProfile"
+                  src="https://an2-img.amz.wtchn.net/image/v2/1bcea716e2558d00efb37cc2422675b4.jpg?jwt=ZXlKaGJHY2lPaUpJVXpJMU5pSjkuZXlKaVlXTnJaM0p2ZFc1a0lqcDdJbklpT2pJMU5Td2laeUk2TWpVMUxDSmlJam95TlRWOUxDSmpjbTl3SWpwMGNuVmxMQ0pvWldsbmFIUWlPalF3TUN3aWNHRjBhQ0k2SWk5Mk1TOWhjR1pvZVhaNmJURXpNVGh4ZFRCcGFHVnFZeUlzSW5GMVlXeHBkSGtpT2pnd0xDSjNhV1IwYUNJNk1qZ3dmUS5ONTVQd1ZrZm5iZDR2d1o3RUpZSTRIWlg2VUxlMS1pLWRkdk1MT3hMd2tZ"
+                />
+              </div>
+              <div className="myProfileColumn">
+                <h1>임유진</h1>
+              </div>
+              <div className="myProfileColumn">
+                <h6>프로필이 없습니다.</h6>
+              </div>
+            </header>
+            <div className="analyzeTest">
+              <div>
+                <button>취향분석</button>
+              </div>
+            </div>
+            <div className="contentBanners">
+              <div className="myMovies">
+                <i class="fas fa-film"></i>
+
+                <p className="contentBannersColumn">영화</p>
+                <p className="contentBannersColumn">
+                  <span>★</span>
+                  <span>14</span>
+                </p>
+                <p className="contentBannersColumn">
+                  <span>보고싶어요</span>
+                  <span>1</span>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    );
+  }
+}

--- a/src/pages/MyPage/MyPage.js
+++ b/src/pages/MyPage/MyPage.js
@@ -2,18 +2,26 @@ import React, { Component } from 'react';
 import './MyPage.scss';
 
 export default class MyPage extends Component {
+  constructor(props) {
+    super(props);
+  }
+
   render() {
     return (
       <section className="myPageSection">
         <div className="myPageContainer">
-          <div className="myHeader">
-            <i class="fas fa-cog"></i>
-          </div>
+          <header className="myHeader">
+            <div className="myHeaderShadow" />
+            <button>
+              <i class="fas fa-cog" />
+            </button>
+          </header>
           <div className="myContents">
             <header className="myProfile">
               <div className="myProfileColumn">
                 <img
                   alt="userProfile"
+                  className="myPageProfileImg"
                   src="https://an2-img.amz.wtchn.net/image/v2/1bcea716e2558d00efb37cc2422675b4.jpg?jwt=ZXlKaGJHY2lPaUpJVXpJMU5pSjkuZXlKaVlXTnJaM0p2ZFc1a0lqcDdJbklpT2pJMU5Td2laeUk2TWpVMUxDSmlJam95TlRWOUxDSmpjbTl3SWpwMGNuVmxMQ0pvWldsbmFIUWlPalF3TUN3aWNHRjBhQ0k2SWk5Mk1TOWhjR1pvZVhaNmJURXpNVGh4ZFRCcGFHVnFZeUlzSW5GMVlXeHBkSGtpT2pnd0xDSjNhV1IwYUNJNk1qZ3dmUS5ONTVQd1ZrZm5iZDR2d1o3RUpZSTRIWlg2VUxlMS1pLWRkdk1MT3hMd2tZ"
                 />
               </div>
@@ -26,24 +34,24 @@ export default class MyPage extends Component {
             </header>
             <div className="analyzeTest">
               <div>
-                <button>취향분석</button>
+                <button className="analyzeBtn">
+                  <i class="fas fa-chart-bar" />
+                  취향분석
+                </button>
               </div>
             </div>
             <div className="contentBanners">
-              <div className="myMovies">
-                <button>
-                  <i class="fas fa-film"></i>
-                  <p className="contentBannersColumn">영화</p>
-                  <p className="contentBannersColumn">
-                    <span>★</span>
-                    <span>14</span>
-                  </p>
-                  <p className="contentBannersColumn">
-                    <span>보고싶어요</span>
-                    <span>1</span>
-                  </p>
-                </button>
-              </div>
+              <button className="myMovies">
+                <p className="contentBannersColumn">영화</p>
+                <p className="contentBannersColumn">
+                  <span>★</span>
+                  <span>14</span>
+                </p>
+                <p className="contentBannersColumn">
+                  <span>보고싶어요</span>
+                  <span>1</span>
+                </p>
+              </button>
             </div>
           </div>
         </div>

--- a/src/pages/MyPage/MyPage.js
+++ b/src/pages/MyPage/MyPage.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
+import { withRouter } from 'react-router-dom';
 import './MyPage.scss';
 
-export default class MyPage extends Component {
+class MyPage extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -23,7 +24,12 @@ export default class MyPage extends Component {
       .then(res => {
         if (res.status === 200) {
           return res.json();
-        } else alert('로그인해주세요');
+        }
+      })
+      .catch(error => {
+        alert('로그인해주세요');
+        this.props.history.push('/');
+        return;
       })
       .then(userRatedData => {
         this.setState({
@@ -82,3 +88,5 @@ export default class MyPage extends Component {
     );
   }
 }
+
+export default withRouter(MyPage);

--- a/src/pages/MyPage/MyPage.js
+++ b/src/pages/MyPage/MyPage.js
@@ -5,14 +5,15 @@ export default class MyPage extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      userRatedData: [],
+      userData: [],
     };
   }
 
   componentDidMount() {
-    let token = localStorage.getItem('TOKEN') || '';
+    let token = localStorage.getItem('TOKEN');
     fetch(
       '/data/userArchiveData.json'
+      // ToDo : BE와 테스트
       //  {
       //   headers: {
       //     Authorization: token,
@@ -22,16 +23,19 @@ export default class MyPage extends Component {
       .then(res => {
         if (res.status === 200) {
           return res.json();
-        }
+        } else alert('로그인해주세요');
       })
       .then(userRatedData => {
         this.setState({
-          userRatedData: userRatedData['result'],
+          userData: userRatedData.result,
         });
       });
   }
 
   render() {
+    const userName = this.state.userData[0]?.userName;
+    const moviesCount = this.state.userData[0]?.moviesCount;
+    const wantedCount = this.state.userData[0]?.wantedCount;
     return (
       <section className="myPageSection">
         <div className="myPageContainer">
@@ -44,14 +48,10 @@ export default class MyPage extends Component {
           <div className="myContents">
             <header className="myProfile">
               <div className="myProfileColumn">
-                <img
-                  alt="userProfile"
-                  className="myPageProfileImg"
-                  src="https://an2-img.amz.wtchn.net/image/v2/1bcea716e2558d00efb37cc2422675b4.jpg?jwt=ZXlKaGJHY2lPaUpJVXpJMU5pSjkuZXlKaVlXTnJaM0p2ZFc1a0lqcDdJbklpT2pJMU5Td2laeUk2TWpVMUxDSmlJam95TlRWOUxDSmpjbTl3SWpwMGNuVmxMQ0pvWldsbmFIUWlPalF3TUN3aWNHRjBhQ0k2SWk5Mk1TOWhjR1pvZVhaNmJURXpNVGh4ZFRCcGFHVnFZeUlzSW5GMVlXeHBkSGtpT2pnd0xDSjNhV1IwYUNJNk1qZ3dmUS5ONTVQd1ZrZm5iZDR2d1o3RUpZSTRIWlg2VUxlMS1pLWRkdk1MT3hMd2tZ"
-                />
+                <i className="fas fa-user-circle myPageProfileImg" />
               </div>
               <div className="myProfileColumn">
-                <h1>임유진</h1>
+                <h1>{userName}</h1>
               </div>
               <div className="myProfileColumn">
                 <h6>프로필이 없습니다.</h6>
@@ -70,11 +70,11 @@ export default class MyPage extends Component {
                 <p className="contentBannersColumn">영화</p>
                 <p className="contentBannersColumn">
                   <span>★</span>
-                  <span>14</span>
+                  <span>{moviesCount}</span>
                 </p>
                 <p className="contentBannersColumn">
                   <span>보고싶어요</span>
-                  <span>1</span>
+                  <span className="myPageWantedCount">{wantedCount}</span>
                 </p>
               </button>
             </div>

--- a/src/pages/MyPage/MyPage.js
+++ b/src/pages/MyPage/MyPage.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
+import API_URLS from '../../config';
 import './MyPage.scss';
 
 class MyPage extends Component {
@@ -12,15 +13,11 @@ class MyPage extends Component {
 
   componentDidMount() {
     let token = localStorage.getItem('TOKEN');
-    fetch(
-      '/data/userArchiveData.json'
-      // ToDo : BE와 테스트
-      //  {
-      //   headers: {
-      //     Authorization: token,
-      //   },
-      // }
-    )
+    fetch(API_URLS.MYPAGE, {
+      headers: {
+        Authorization: token,
+      },
+    })
       .then(res => {
         if (res.status === 200) {
           return res.json();
@@ -29,17 +26,21 @@ class MyPage extends Component {
       .catch(error => {
         alert('로그인해주세요');
         this.props.history.push('/');
-        return;
       })
       .then(userRatedData => {
+        localStorage.setItem('NAME', userRatedData.result.name);
         this.setState({
           userData: userRatedData.result,
         });
       });
   }
 
+  goToMyTest = () => {
+    this.props.history.push('/mytest');
+  };
+
   render() {
-    const { userName, moviesCount, wantedCount } = this.state.userData[0];
+    const { userData } = this.state || '';
     return (
       <section className="myPageSection">
         <div className="myPageContainer">
@@ -55,7 +56,7 @@ class MyPage extends Component {
                 <i className="fas fa-user-circle myPageProfileImg" />
               </div>
               <div className="myProfileColumn">
-                <h1>{userName}</h1>
+                <h1>{userData.name}</h1>
               </div>
               <div className="myProfileColumn">
                 <h6>프로필이 없습니다.</h6>
@@ -63,7 +64,7 @@ class MyPage extends Component {
             </header>
             <div className="analyzeTest">
               <div>
-                <button className="analyzeBtn">
+                <button onClick={this.goToMyTest} className="analyzeBtn">
                   <i class="fas fa-chart-bar" />
                   취향분석
                 </button>
@@ -74,11 +75,13 @@ class MyPage extends Component {
                 <p className="contentBannersColumn">영화</p>
                 <p className="contentBannersColumn">
                   <span>★</span>
-                  <span>{moviesCount}</span>
+                  <span>{userData['rating_count']}</span>
                 </p>
                 <p className="contentBannersColumn">
                   <span>보고싶어요</span>
-                  <span className="myPageWantedCount">{wantedCount}</span>
+                  <span className="myPageWantedCount">
+                    {userData['wish_count']}
+                  </span>
                 </p>
               </button>
             </div>

--- a/src/pages/MyPage/MyPage.js
+++ b/src/pages/MyPage/MyPage.js
@@ -31,17 +31,18 @@ export default class MyPage extends Component {
             </div>
             <div className="contentBanners">
               <div className="myMovies">
-                <i class="fas fa-film"></i>
-
-                <p className="contentBannersColumn">영화</p>
-                <p className="contentBannersColumn">
-                  <span>★</span>
-                  <span>14</span>
-                </p>
-                <p className="contentBannersColumn">
-                  <span>보고싶어요</span>
-                  <span>1</span>
-                </p>
+                <button>
+                  <i class="fas fa-film"></i>
+                  <p className="contentBannersColumn">영화</p>
+                  <p className="contentBannersColumn">
+                    <span>★</span>
+                    <span>14</span>
+                  </p>
+                  <p className="contentBannersColumn">
+                    <span>보고싶어요</span>
+                    <span>1</span>
+                  </p>
+                </button>
               </div>
             </div>
           </div>

--- a/src/pages/MyPage/MyPage.js
+++ b/src/pages/MyPage/MyPage.js
@@ -33,9 +33,7 @@ export default class MyPage extends Component {
   }
 
   render() {
-    const userName = this.state.userData[0]?.userName;
-    const moviesCount = this.state.userData[0]?.moviesCount;
-    const wantedCount = this.state.userData[0]?.wantedCount;
+    const { userName, moviesCount, wantedCount } = this.state.userData[0];
     return (
       <section className="myPageSection">
         <div className="myPageContainer">

--- a/src/pages/MyPage/MyPage.scss
+++ b/src/pages/MyPage/MyPage.scss
@@ -68,10 +68,13 @@
           position: absolute;
           top: -25px;
           left: 0;
-          height: 60px;
-          width: 60px;
-          border: 1px solid $line;
-          border-radius: 50%;
+          color: $line;
+          font-size: 60px;
+
+          &::before {
+            background-color: $section-aside-text;
+            border-radius: 50%;
+          }
         }
       }
 
@@ -138,6 +141,10 @@
             &:last-of-type {
               margin-top: 90px;
               font-size: 13px;
+
+              .myPageWantedCount {
+                margin-left: 5px;
+              }
             }
           }
         }

--- a/src/pages/MyPage/MyPage.scss
+++ b/src/pages/MyPage/MyPage.scss
@@ -34,7 +34,7 @@
         top: 15px;
         right: 15px;
         color: white;
-        font-size: 20px;
+        font-size: 1.25rem;
       }
     }
 
@@ -53,14 +53,14 @@
           &:nth-of-type(2) {
             margin-top: 40px;
             height: 30px;
-            font-size: 25px;
+            font-size: 1.563rem;
             font-weight: 700;
           }
 
           &:nth-of-type(3) {
             height: 35px;
             color: $menu-normal-text;
-            font-size: 15px;
+            font-size: 0.9375rem;
           }
         }
 
@@ -69,7 +69,7 @@
           top: -25px;
           left: 0;
           color: $line;
-          font-size: 60px;
+          font-size: 3.75rem;
 
           &::before {
             background-color: $section-aside-text;
@@ -88,13 +88,13 @@
 
         .analyzeBtn {
           @include flexSet;
-          font-size: 17px;
+          font-size: 1.063rem;
 
           .fa-chart-bar {
             content: '\f080';
             margin-right: 10px;
             color: tomato;
-            font-size: 25px;
+            font-size: 1.563rem;
             font-family: 'Font Awesome 5 Free';
             font-weight: 900;
             background: linear-gradient(50deg, tomato 40%, gold);
@@ -120,7 +120,7 @@
             top: 0px;
             right: 30px;
             color: white;
-            font-size: 200px;
+            font-size: 12.5rem;
             font-family: 'Font Awesome 5 Free';
             font-weight: 900;
             opacity: 0.5;
@@ -131,16 +131,16 @@
             padding: 8px 10px 0 10px;
 
             &:first-of-type {
-              font-size: 17px;
+              font-size: 1.063rem;
             }
 
             &:nth-of-type(2) {
-              font-size: 19px;
+              font-size: 1.188rem;
             }
 
             &:last-of-type {
               margin-top: 90px;
-              font-size: 13px;
+              font-size: 0.8125rem;
 
               .myPageWantedCount {
                 margin-left: 5px;

--- a/src/pages/MyPage/MyPage.scss
+++ b/src/pages/MyPage/MyPage.scss
@@ -12,6 +12,15 @@
     border: 1px solid $line;
     border-radius: 7px;
 
+    .myHeaderShadow {
+      position: absolute;
+      top: 0px;
+      right: 0px;
+      left: 0px;
+      height: 50px;
+      background: linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0));
+    }
+
     .myHeader {
       position: relative;
       width: 640px;
@@ -20,21 +29,12 @@
       border-top-left-radius: 7px;
       border-top-right-radius: 7px;
 
-      &::before {
-        content: '';
-        position: absolute;
-        top: 0px;
-        right: 0px;
-        left: 0px;
-        display: block;
-        background: linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0));
-      }
-
       .fa-cog {
         position: absolute;
         top: 15px;
         right: 15px;
         color: white;
+        font-size: 20px;
       }
     }
 
@@ -64,7 +64,7 @@
           }
         }
 
-        img {
+        .myPageProfileImg {
           position: absolute;
           top: -25px;
           left: 0;
@@ -83,8 +83,21 @@
         border-top: 1px solid $line;
         border-bottom: 1px solid $line;
 
-        button {
+        .analyzeBtn {
+          @include flexSet;
           font-size: 17px;
+
+          .fa-chart-bar {
+            content: '\f080';
+            margin-right: 10px;
+            color: tomato;
+            font-size: 25px;
+            font-family: 'Font Awesome 5 Free';
+            font-weight: 900;
+            background: linear-gradient(50deg, tomato 40%, gold);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+          }
         }
       }
 
@@ -98,13 +111,17 @@
           border-radius: 8px;
           color: white;
 
-          .fa-film {
+          &::before {
+            content: '\f008';
             position: absolute;
+            top: 0px;
             right: 30px;
-            bottom: -50px;
-            font-size: 250px;
-            overflow: hidden;
+            color: white;
+            font-size: 200px;
+            font-family: 'Font Awesome 5 Free';
+            font-weight: 900;
             opacity: 0.5;
+            overflow: hidden;
           }
 
           .contentBannersColumn {
@@ -119,7 +136,7 @@
             }
 
             &:last-of-type {
-              margin-top: 120px;
+              margin-top: 90px;
               font-size: 13px;
             }
           }

--- a/src/pages/MyPage/MyPage.scss
+++ b/src/pages/MyPage/MyPage.scss
@@ -1,7 +1,6 @@
 @import '../../styles/variables.scss';
 
 .myPageSection {
-  height: 100vh;
   @include flexColumnSet;
   padding: 62px 0;
   background-color: $section-background;
@@ -14,20 +13,20 @@
     border-radius: 7px;
 
     .myHeader {
+      position: relative;
       width: 640px;
       height: 200px;
       background: linear-gradient(#e76d90, #e882a3);
       border-top-left-radius: 7px;
       border-top-right-radius: 7px;
-      position: relative;
 
       &::before {
         content: '';
-        display: block;
         position: absolute;
         top: 0px;
         right: 0px;
         left: 0px;
+        display: block;
         background: linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0));
       }
 
@@ -43,9 +42,9 @@
       @include flexColumnSet;
 
       .myProfile {
+        position: relative;
         @include flexColumnSet;
         background-color: white;
-        position: relative;
 
         .myProfileColumn {
           @include flexSet(flex-start);
@@ -60,8 +59,8 @@
 
           &:nth-of-type(3) {
             height: 35px;
-            font-size: 15px;
             color: $menu-normal-text;
+            font-size: 15px;
           }
         }
 
@@ -71,18 +70,19 @@
           left: 0;
           height: 60px;
           width: 60px;
-          border-radius: 50%;
           border: 1px solid $line;
+          border-radius: 50%;
         }
       }
 
       .analyzeTest {
         @include flexSet(flex-start);
+        margin: 20px 0;
         width: 598px;
         height: 48px;
         border-top: 1px solid $line;
         border-bottom: 1px solid $line;
-        margin: 20px 0;
+
         button {
           font-size: 17px;
         }
@@ -100,21 +100,24 @@
 
           .fa-film {
             position: absolute;
-            overflow: hidden;
             right: 30px;
             bottom: -50px;
             font-size: 250px;
+            overflow: hidden;
             opacity: 0.5;
           }
 
           .contentBannersColumn {
             padding: 8px 10px 0 10px;
+
             &:first-of-type {
               font-size: 17px;
             }
+
             &:nth-of-type(2) {
               font-size: 19px;
             }
+
             &:last-of-type {
               margin-top: 120px;
               font-size: 13px;

--- a/src/pages/MyPage/MyPage.scss
+++ b/src/pages/MyPage/MyPage.scss
@@ -1,0 +1,127 @@
+@import '../../styles/variables.scss';
+
+.myPageSection {
+  height: 100vh;
+  @include flexColumnSet;
+  padding: 62px 0;
+  background-color: $section-background;
+
+  .myPageContainer {
+    margin: 30px 0;
+    height: 620px;
+    background-color: white;
+    border: 1px solid $line;
+    border-radius: 7px;
+
+    .myHeader {
+      width: 640px;
+      height: 200px;
+      background: linear-gradient(#e76d90, #e882a3);
+      border-top-left-radius: 7px;
+      border-top-right-radius: 7px;
+      position: relative;
+
+      &::before {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 0px;
+        right: 0px;
+        left: 0px;
+        background: linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0));
+      }
+
+      .fa-cog {
+        position: absolute;
+        top: 15px;
+        right: 15px;
+        color: white;
+      }
+    }
+
+    .myContents {
+      @include flexColumnSet;
+
+      .myProfile {
+        @include flexColumnSet;
+        background-color: white;
+        position: relative;
+
+        .myProfileColumn {
+          @include flexSet(flex-start);
+          width: 598px;
+
+          &:nth-of-type(2) {
+            margin-top: 40px;
+            height: 30px;
+            font-size: 25px;
+            font-weight: 700;
+          }
+
+          &:nth-of-type(3) {
+            height: 35px;
+            font-size: 15px;
+            color: $menu-normal-text;
+          }
+        }
+
+        img {
+          position: absolute;
+          top: -25px;
+          left: 0;
+          height: 60px;
+          width: 60px;
+          border-radius: 50%;
+          border: 1px solid $line;
+        }
+      }
+
+      .analyzeTest {
+        @include flexSet(flex-start);
+        width: 598px;
+        height: 48px;
+        border-top: 1px solid $line;
+        border-bottom: 1px solid $line;
+        margin: 20px 0;
+        button {
+          font-size: 17px;
+        }
+      }
+
+      .contentBanners {
+        .myMovies {
+          position: relative;
+          @include flexColumnSet(none, none);
+          height: 200px;
+          width: 600px;
+          background: linear-gradient(70deg, #82d957, #bbe772);
+          border-radius: 8px;
+          color: white;
+
+          .fa-film {
+            position: absolute;
+            overflow: hidden;
+            right: 30px;
+            bottom: -50px;
+            font-size: 250px;
+            opacity: 0.5;
+          }
+
+          .contentBannersColumn {
+            padding: 8px 10px 0 10px;
+            &:first-of-type {
+              font-size: 17px;
+            }
+            &:nth-of-type(2) {
+              font-size: 19px;
+            }
+            &:last-of-type {
+              margin-top: 120px;
+              font-size: 13px;
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
>wecode PR message template 및 체크 리스트 입니다. 
아래 사항들을 전부 작성/체크 하시고 PR 해주세요!

## 수정 사항 간략한 한줄 요약
- 🆕 백엔드 분들과 테스트 완료, 데이터 구조 변경에 맞게 수정

- 백엔드 연결 로직 추가, 1차 리뷰 반영 수정, 컨플릭트 해결
- 마이페이지 레이아웃 완성
		 
## 수정 사항들 자세한 내용
- 🆕 백엔드 분들 데이터 구조?에 변경점이 생겨 그에 맞게 수정했습니당
- 🆕 유저 이름을 취향분석 페이지에서도 써야 하는데 넘겨줄 방법을 못찾아서 로컬스토리지에 저장했습니다...

- 백엔드로부터 유저 이름과 평가한 영화 총 개수, 보고싶어요 표시한 영화 개수만 받아와서 화면에 그려줄건데 그 로직 추가
- 불필요한 || 연산자 삭제 (토큰 부분), 에러 발생시 (status code 200 else) 로그인하세요 alert 팝업
- 컨플릭트 해결
- 닷노테이션으로 변경
- 마이페이지 레이아웃 완성

## 기타 질문 및 특이 사항
- 🆕 유저 이름을 취향분석 페이지에서도 써야 하는데 넘겨줄 방법을 못찾아서 로컬스토리지에 저장했습니다..

- 유저 프로필 이미지가 원래 왓챠에서는 등록하는 기능이 없고, sns 연동시 sns 프로필 이미지를 받아온다고 합니다. 저희는 sns 연동은 구현하지 않을 것이라 이미지가 없을때의 그림으로 폰트 어썸 아이콘을 넣었습니다. 이게 아이콘이 사람 모양 부분이 비어있어서 그 뒤롤 background color로 채워줬는데 요게 미세하게 더 커서 넘 거슬립니다. background를 ::before로 설정하지 말고 따로 div를 만들어서 크기를 작게해서 위치를 옮겨주는 거 말고 방법 없을까요? 저 방법은 넘 번거로운거 같아서요... 😢
- PR이 너무 많아서 힘드시면 🥕을 흔들어주세요. 항상 감사해여 연욱님~~~🙇‍♀️
- 안의 데이터는 유저 정보를 백엔드 API에서 받아와 채울 예정입니다! 궁금한게 있는데 마이페이지 화면에선 이 유저가 별점 평가한 영화가 몇 개인지 그 수를 보여줘야 하고 거기서 버튼을 누르면 다음 페이지로 이동되어 거기서 자기가 평가했던 영화 목록이 쫙 뜹니당. 
이때  전체의 데이터를 받아와 프론트에서 개수 카운트하는 로직 짜서 총 개수를 보여주나요 아니면 백엔드에서 카운트를 해서 개수만 보내주면 그걸 받아서 보여주고 전체 데이터는 다음 페이지에서 다시 get요청으로 받나요? 
뭔가 대부분의 데이터 처리나 로직을 백엔드에서 다 맡아하는 느낌이라 넘 부담 지우는거 같기도 하고 한편으론 프론트는 하는 일이 없는거 같기도 하고 (물론 아직 트렐로에 남은건 산더미) 의문이 들어서요!! 개수 카운트나 그외 다른 작업들.. 예를 들어 장르 필터링 같은건 어케보면 데이터를 원하는 형태로 보여주는거나 다름이 없지 않나 - 프론트에서 해도 되지 않나 하는 생각이 들었는데 보통은 어떻게 하나요?

## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge가 됩니다!)
- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] Wecode의 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
