### PR TITLE
[20기 임유진] Fix : Footer를 라우트에서 조건부렌더링 하지 않고 footer 내부에서 조건부 렌더링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+EasterEgg.js

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -19,16 +19,10 @@ class Routes extends React.Component {
           {/* <Route exact path="/contents" component={}></Route> */}
           {/* <Route exact path="/myPage" component={}></Route> */}
         </Switch>
-        {location.pathname !== '/review' && <Footer />}
+        <Footer />
       </Router>
     );
   }
 }
 
 export default Routes;
-
-/* global history */
-/* global location */
-/* global window */
-
-/* eslint no-restricted-globals: ["off"] */

--- a/src/pages/CommonComponents/EasterEgg.scss
+++ b/src/pages/CommonComponents/EasterEgg.scss
@@ -1,0 +1,16 @@
+@import '../../styles/variables.scss';
+
+.easterEgg {
+  @include flexColumnSet(space-between);
+  padding: 50px;
+
+  .easterEggHeader {
+    margin-bottom: 50px;
+    font-weight: 700;
+  }
+
+  .thanksPeople {
+    margin-bottom: 10px;
+    font-size: 0.875rem;
+  }
+}

--- a/src/pages/CommonComponents/Footer.js
+++ b/src/pages/CommonComponents/Footer.js
@@ -1,52 +1,81 @@
 import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
+import Modal from './Modal';
+import EasterEgg from './EasterEgg';
 import './Footer.scss';
 
 class Footer extends Component {
+  constructor() {
+    super();
+    this.state = {
+      modalOpened: false,
+    };
+  }
+
+  closeModal = () => {
+    this.setState({
+      modalOpened: false,
+    });
+  };
+
+  handleEasterEgg = () => {
+    this.setState({
+      modalOpened: true,
+    });
+  };
+
   render() {
     const currentPage = this.props.location.pathname;
+    if (currentPage === '/review' || currentPage === '/mytest') return null;
     return (
       <>
-        {currentPage !== '/review' && (
-          <footer className="commonFooter">
-            <section className="evaluationFooter">
-              <span>
-                지금까지 <span className="footerCounter">얼마</span>의 평가
+        {this.state.modalOpened && (
+          <Modal closeModal={this.closeModal} childComponent={<EasterEgg />} />
+        )}
+        <footer className="commonFooter">
+          <section className="evaluationFooter">
+            <span>
+              지금까지{' '}
+              <span onClick={this.handleEasterEgg} className="footerCounter">
+                얼마
               </span>
-            </section>
-            <section className="descriptionFooter">
-              <div className="siteDescription">
-                <ul>
-                  <li>
-                    <span>이 사이트는 공식 왓챠 사이트가 아닙니다</span>
-                  </li>
-                  <li>
-                    <span>이 사이트는 공식 왓챠 사이트와 관련이 없습니다</span>
-                  </li>
-                  <li>
-                    <span>
-                      이 사이트는 학생들이 공부용으로 만든 클론 프로젝트
-                      사이트입니다
-                    </span>
-                  </li>
-                </ul>
-              </div>
-              <div className="memberDescription">
-                <ul>
-                  {MEMBER_LIST.map(member => {
+              의 평가
+            </span>
+          </section>
+          <section className="descriptionFooter">
+            <div className="siteDescription">
+              <ul>
+                <li>
+                  <span>이 사이트는 공식 왓챠 사이트가 아닙니다</span>
+                </li>
+                <li>
+                  <span>이 사이트는 공식 왓챠 사이트와 관련이 없습니다</span>
+                </li>
+                <li>
+                  <span>
+                    이 사이트는 학생들이 공부용으로 만든 클론 프로젝트
+                    사이트입니다
+                  </span>
+                </li>
+              </ul>
+            </div>
+            <div className="memberDescription">
+              <ul>
+                {MEMBER_LIST.map(member => {
+                  return (
                     <li key={member.id}>
                       <button>
                         <a href={member.blog} target="_blank">
                           <span>{member.name}</span>
                         </a>
                       </button>
-                    </li>;
-                  })}
-                </ul>
-              </div>
-            </section>
-          </footer>
-        )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          </section>
+        </footer>
       </>
     );
   }

--- a/src/pages/CommonComponents/Footer.js
+++ b/src/pages/CommonComponents/Footer.js
@@ -34,15 +34,13 @@ class Footer extends Component {
               <div className="memberDescription">
                 <ul>
                   {MEMBER_LIST.map(member => {
-                    return (
-                      <li key={member.id}>
-                        <button>
-                          <a href={member.blog} target="_blank">
-                            <span>{member.name}</span>
-                          </a>
-                        </button>
-                      </li>
-                    );
+                    <li key={member.id}>
+                      <button>
+                        <a href={member.blog} target="_blank">
+                          <span>{member.name}</span>
+                        </a>
+                      </button>
+                    </li>;
                   })}
                 </ul>
               </div>

--- a/src/pages/CommonComponents/Footer.js
+++ b/src/pages/CommonComponents/Footer.js
@@ -1,52 +1,60 @@
 import React, { Component } from 'react';
+import { withRouter } from 'react-router-dom';
 import './Footer.scss';
 
-export default class Footer extends Component {
+class Footer extends Component {
   render() {
+    const currentPage = this.props.location.pathname;
     return (
-      <footer className="commonFooter">
-        <section className="evaluationFooter">
-          <span>
-            지금까지 <span className="footerCounter">얼마</span>의 평가
-          </span>
-        </section>
-        <section className="descriptionFooter">
-          <div className="siteDescription">
-            <ul>
-              <li>
-                <span>이 사이트는 공식 왓챠 사이트가 아닙니다</span>
-              </li>
-              <li>
-                <span>이 사이트는 공식 왓챠 사이트와 관련이 없습니다</span>
-              </li>
-              <li>
-                <span>
-                  이 사이트는 학생들이 공부용으로 만든 클론 프로젝트
-                  사이트입니다
-                </span>
-              </li>
-            </ul>
-          </div>
-          <div className="memberDescription">
-            <ul>
-              {MEMBER_LIST.map(member => {
-                return (
-                  <li key={member.id}>
-                    <button>
-                      <a href={member.blog} target="_blank">
-                        <span>{member.name}</span>
-                      </a>
-                    </button>
+      <>
+        {currentPage !== '/review' && (
+          <footer className="commonFooter">
+            <section className="evaluationFooter">
+              <span>
+                지금까지 <span className="footerCounter">얼마</span>의 평가
+              </span>
+            </section>
+            <section className="descriptionFooter">
+              <div className="siteDescription">
+                <ul>
+                  <li>
+                    <span>이 사이트는 공식 왓챠 사이트가 아닙니다</span>
                   </li>
-                );
-              })}
-            </ul>
-          </div>
-        </section>
-      </footer>
+                  <li>
+                    <span>이 사이트는 공식 왓챠 사이트와 관련이 없습니다</span>
+                  </li>
+                  <li>
+                    <span>
+                      이 사이트는 학생들이 공부용으로 만든 클론 프로젝트
+                      사이트입니다
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div className="memberDescription">
+                <ul>
+                  {MEMBER_LIST.map(member => {
+                    return (
+                      <li key={member.id}>
+                        <button>
+                          <a href={member.blog} target="_blank">
+                            <span>{member.name}</span>
+                          </a>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            </section>
+          </footer>
+        )}
+      </>
     );
   }
 }
+
+export default withRouter(Footer);
 
 const MEMBER_LIST = [
   { id: 1, name: '임유진', blog: 'https://velog.io/@1703979' },


### PR DESCRIPTION
>wecode PR message template 및 체크 리스트 입니다. 
아래 사항들을 전부 작성/체크 하시고 PR 해주세요!

## 수정 사항 간략한 한줄 요약
- 🆕 백엔드와 연결하여 테스트 완료
		 
## 수정 사항들 자세한 내용
- 🆕 백엔드와 연결하여 문제점 픽스 확인 완료~! 
- 라우트 파일 내부에서 로케이션 패스네임으로 직접 조건부 렌더링 하지 않고 footer 컴포넌트롤 withRouter적용하여 props로 받아 조건부렌더링하는 것으로 바꿨습니다. 근데 아직 백이랑 연결해서 문제점이 픽스 됐는지 테스트는 못해봤습니다 

## 기타 질문 및 특이 사항


## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge가 됩니다!)
- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] Wecode의 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
